### PR TITLE
fixed arginfo warnings

### DIFF
--- a/gnupg.c
+++ b/gnupg.c
@@ -286,6 +286,9 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_gnupg_decryptverify_method, 0, 0, 2)
 ZEND_END_ARG_INFO()
 /* }}} */
 
+ZEND_BEGIN_ARG_INFO_EX(arginfo_void, 0, 0, 0)
+ZEND_END_ARG_INFO()
+
 #define PHP_GNUPG_FALIAS(_name, _arginfo) \
 	PHP_FALIAS(_name, gnupg_ ## _name, _arginfo)
 
@@ -294,17 +297,17 @@ phpc_function_entry gnupg_methods[] = {
 	PHP_ME(gnupg, __construct, arginfo_gnupg_init, ZEND_ACC_CTOR|ZEND_ACC_PUBLIC)
 	PHP_GNUPG_FALIAS(keyinfo,           arginfo_gnupg_keyinfo_method)
 	PHP_GNUPG_FALIAS(verify,            arginfo_gnupg_verify_method)
-	PHP_GNUPG_FALIAS(getengineinfo,     NULL)
-	PHP_GNUPG_FALIAS(geterror,          NULL)
-	PHP_GNUPG_FALIAS(clearsignkeys,     NULL)
-	PHP_GNUPG_FALIAS(clearencryptkeys,  NULL)
-	PHP_GNUPG_FALIAS(cleardecryptkeys,  NULL)
+	PHP_GNUPG_FALIAS(getengineinfo,     arginfo_void)
+	PHP_GNUPG_FALIAS(geterror,          arginfo_void)
+	PHP_GNUPG_FALIAS(clearsignkeys,     arginfo_void)
+	PHP_GNUPG_FALIAS(clearencryptkeys,  arginfo_void)
+	PHP_GNUPG_FALIAS(cleardecryptkeys,  arginfo_void)
 	PHP_GNUPG_FALIAS(setarmor,          arginfo_gnupg_armor_method)
 	PHP_GNUPG_FALIAS(encrypt,           arginfo_gnupg_text_method)
 	PHP_GNUPG_FALIAS(decrypt,           arginfo_gnupg_enctext_method)
 	PHP_GNUPG_FALIAS(export,            arginfo_gnupg_pattern_method)
 	PHP_GNUPG_FALIAS(import,            arginfo_gnupg_key_method)
-	PHP_GNUPG_FALIAS(getprotocol,       NULL)
+	PHP_GNUPG_FALIAS(getprotocol,       arginfo_void)
 	PHP_GNUPG_FALIAS(setsignmode,       arginfo_gnupg_signmode_method)
 	PHP_GNUPG_FALIAS(sign,              arginfo_gnupg_text_method)
 	PHP_GNUPG_FALIAS(encryptsign,       arginfo_gnupg_text_method)

--- a/gnupg_keylistiterator.c
+++ b/gnupg_keylistiterator.c
@@ -84,14 +84,17 @@ PHPC_OBJ_HANDLER_CREATE(gnupg_keylistiterator)
 	PHPC_OBJ_HANDLER_CREATE_RETURN(gnupg_keylistiterator);
 }
 
+ZEND_BEGIN_ARG_INFO_EX(arginfo_void, 0, 0, 0)
+ZEND_END_ARG_INFO()
+
 /* {{{ method list gnupg_keylistiterator */
 static zend_function_entry gnupg_keylistiterator_methods[] = {
-	PHP_ME(gnupg_keylistiterator, __construct, NULL, ZEND_ACC_PUBLIC)
-	PHP_ME(gnupg_keylistiterator, current, NULL, ZEND_ACC_PUBLIC)
-	PHP_ME(gnupg_keylistiterator, key, NULL, ZEND_ACC_PUBLIC)
-	PHP_ME(gnupg_keylistiterator, next, NULL, ZEND_ACC_PUBLIC)
-	PHP_ME(gnupg_keylistiterator, rewind, NULL, ZEND_ACC_PUBLIC)
-	PHP_ME(gnupg_keylistiterator, valid, NULL, ZEND_ACC_PUBLIC)
+	PHP_ME(gnupg_keylistiterator, __construct, arginfo_void, ZEND_ACC_PUBLIC)
+	PHP_ME(gnupg_keylistiterator, current, arginfo_void, ZEND_ACC_PUBLIC)
+	PHP_ME(gnupg_keylistiterator, key, arginfo_void, ZEND_ACC_PUBLIC)
+	PHP_ME(gnupg_keylistiterator, next, arginfo_void, ZEND_ACC_PUBLIC)
+	PHP_ME(gnupg_keylistiterator, rewind, arginfo_void, ZEND_ACC_PUBLIC)
+	PHP_ME(gnupg_keylistiterator, valid, arginfo_void, ZEND_ACC_PUBLIC)
 	PHPC_FE_END
 };
 /* }}} */


### PR DESCRIPTION
fixed the arginfo warnings by php 8.0.x which broke laravel valet for me.